### PR TITLE
using junit5 and killing test-common

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,25 +29,23 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()
+    implementation gradleApi()
 
     //https://www.jfrog.com/confluence/display/RTF/Gradle+Artifactory+Plugin
     //https://github.com/JFrogDev/build-info/tree/master/build-info-extractor-gradle
-    compile 'org.jfrog.buildinfo:build-info-extractor-gradle:4.6.0'
+    implementation 'org.jfrog.buildinfo:build-info-extractor-gradle:4.6.0'
 
     //https://github.com/hierynomus/license-gradle-plugin
-    compile 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
+    implementation 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
 
     //https://github.com/kt3k/coveralls-gradle-plugin
-    compile 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
+    implementation 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
 
     //https://github.com/Codearte/gradle-nexus-staging-plugin
-    compile 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
+    implementation 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
 
     //https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+Gradle
-    compile 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1'
-
-    compile 'com.blackducksoftware.integration:integration-test-common:[4.0.0,)'
+    implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1'
 }
 
 configurations.all { resolutionStrategy { force 'org.codehaus.groovy:groovy-all:2.4.12' } }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
 tasks.withType(GroovyCompile) { options.encoding = 'UTF-8' }
 
 group = 'com.blackducksoftware.integration'
-version = '0.0.40-SNAPSHOT'
+version = '0.0.40'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/LibraryPlugin.groovy
+++ b/src/main/groovy/LibraryPlugin.groovy
@@ -133,4 +133,5 @@ class LibraryPlugin extends Common {
         project.tasks.getByName('releaseRepository').onlyIf { !project.isSnapshot }
         project.tasks.getByName('releaseRepository').dependsOn 'uploadArchives'
     }
+
 }

--- a/src/main/groovy/SolutionPlugin.groovy
+++ b/src/main/groovy/SolutionPlugin.groovy
@@ -27,8 +27,7 @@ import org.gradle.api.Project
 /**
  * This plugin is meant for final integration solutions. They can create the
  * 'mavenJava' publication for uploading to artifactory, overloading the
- * 'artifactoryRepo' property to affect the destination repository.
- */
+ * 'artifactoryRepo' property to affect the destination repository.*/
 class SolutionPlugin extends Common {
     void apply(Project project) {
         super.apply(project)
@@ -45,4 +44,5 @@ class SolutionPlugin extends Common {
         String artifactoryRepo = project.ext.artifactoryRepo
         configureDefaultsForArtifactory(project, artifactoryRepo)
     }
+
 }


### PR DESCRIPTION
In support of junit 5, this adds some custom tasks and allows for even further customization via project.ext.junitPlatformDefaultTestTags and project.ext.junitPlatformDefaultTestTags.