### PR TITLE
Add logic to allow exclusions from Sonar

### DIFF
--- a/src/main/groovy/com/synopsys/integration/Common.groovy
+++ b/src/main/groovy/com/synopsys/integration/Common.groovy
@@ -1,10 +1,3 @@
-package com.synopsys.integration
-
-import com.hierynomus.gradle.license.LicenseBasePlugin
-import com.synopsys.integration.utility.BuildFileUtility
-import com.synopsys.integration.utility.VersionUtility
-import nl.javadude.gradle.plugins.license.LicenseExtension
-
 /*
  * common-gradle-plugin
  *
@@ -27,7 +20,12 @@ import nl.javadude.gradle.plugins.license.LicenseExtension
  * specific language governing permissions and limitations
  * under the License.
  */
+package com.synopsys.integration
 
+import com.hierynomus.gradle.license.LicenseBasePlugin
+import com.synopsys.integration.utility.BuildFileUtility
+import com.synopsys.integration.utility.VersionUtility
+import nl.javadude.gradle.plugins.license.LicenseExtension
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.*
 import org.gradle.api.plugins.JavaPluginConvention
@@ -69,6 +67,7 @@ public abstract class Common implements Plugin<Project> {
     public static final String PROPERTY_SYNOPSYS_OVERRIDE_INTEGRATION_GIT_IGNORE = 'synopsysOverrideIntegrationGitIgnore'
     public static final String PROPERTY_SYNOPSYS_OVERRIDE_INTEGRATION_README = 'synopsysOverrideIntegrationReadme'
     public static final String PROPERTY_BUILDSCRIPT_DEPENDENCY = 'buildscriptDependency'
+    public static final String PROPERTY_EXCLUDES_FROM_TEST_COVERAGE = 'excludesFromTestCoverage'
 
     public static final String PROPERTY_ARTIFACTORY_DEPLOYER_USERNAME = 'artifactoryDeployerUsername'
     public static final String PROPERTY_ARTIFACTORY_DEPLOYER_PASSWORD = 'artifactoryDeployerPassword'
@@ -103,6 +102,9 @@ public abstract class Common implements Plugin<Project> {
         setExtPropertyOnProject(project, PROPERTY_SYNOPSYS_OVERRIDE_INTEGRATION_LICENSE, 'false')
         setExtPropertyOnProject(project, PROPERTY_SYNOPSYS_OVERRIDE_INTEGRATION_GIT_IGNORE, 'true')
         setExtPropertyOnProject(project, PROPERTY_SYNOPSYS_OVERRIDE_INTEGRATION_README, 'true')
+
+        // By default we should not exclude anything
+        setExtPropertyOnProject(project, PROPERTY_EXCLUDES_FROM_TEST_COVERAGE, '')
 
         // there is no default public artifactory for deploying
         setExtPropertyOnProject(project, PROPERTY_DEPLOY_ARTIFACTORY_URL, '')
@@ -267,8 +269,13 @@ public abstract class Common implements Plugin<Project> {
 
     public void configureForJacoco(Project project) {
         project.plugins.apply('jacoco')
-        Task jacocoTask = project.tasks.getByName('jacocoTestReport')
-        jacocoTask.reports {
+
+        def jacocoReportTaskExcludes = StringUtils.replaceEach(project.ext[PROPERTY_EXCLUDES_FROM_TEST_COVERAGE].toString(), ['.java'] as String[], ['.class'] as String[]).split() as ArrayList
+        def jacocoTestTaskExcludes = StringUtils.replaceEach(project.ext[PROPERTY_EXCLUDES_FROM_TEST_COVERAGE].toString(), ['.*', '.class', '.java'] as String[], ['', '', ''] as String[]).split() as ArrayList
+        Task jacocoReportTask = project.tasks.getByName('jacocoTestReport')
+        Task testTask = project.tasks.getByName('test')
+
+        jacocoReportTask.reports {
             // coveralls plugin demands xml format
             xml.enabled = true
             html.enabled = true
@@ -276,29 +283,61 @@ public abstract class Common implements Plugin<Project> {
 
         File jacocoDirectory = new File("${project.buildDir}/jacoco")
         if (jacocoDirectory && jacocoDirectory.exists()) {
-            project.tasks.getByName('jacocoTestReport').executionData(project.files(jacocoDirectory.listFiles()))
+            jacocoReportTask.executionData(project.files(jacocoDirectory.listFiles()))
+        }
+
+        // This handles excludes for the jacocoTestReport task which generates
+        // the file: build/reports/jacoco/test/html/index.html
+        if (jacocoReportTaskExcludes.size() > 0) {
+            if (jacocoReportTask.hasProperty('classDirectories')) {
+                println "Adding the following exclusions to your jacocoTestReport task:"
+                jacocoReportTaskExcludes.each { println "\t" + it }
+
+                project.afterEvaluate {
+                    jacocoReportTask.classDirectories.from = project.files(jacocoReportTask.property('classDirectories').collect {
+                        project.fileTree(dir: it, exclude: jacocoReportTaskExcludes)
+                    })
+                }
+            }
+
+            // This handles excludes for the test.jacoco task which generates
+            // the file: build/jacoco/test.exec
+            println "Adding the following exclusions to your test.jacoco task:"
+            jacocoTestTaskExcludes.each { println "\t" + it }
+            testTask.jacoco.setExcludes(jacocoTestTaskExcludes)
         }
     }
 
     public void configureForSonarQube(Project project) {
+        def sonarExcludes = StringUtils.replaceEach(project.ext[PROPERTY_EXCLUDES_FROM_TEST_COVERAGE].toString(), ['.class'] as String[], ['.java'] as String[]).split() as ArrayList
         def surefireReportPaths = ''
 
         File testResultsDirectory = new File("${project.buildDir}/test-results")
         if (testResultsDirectory && testResultsDirectory.exists()) {
             def allSurefireReportDirectories = project.files(testResultsDirectory.listFiles())
-            surefireReportPaths =
-                    allSurefireReportDirectories
-                            .getFrom()
-                            .collect { project.relativePath(it) }
-                            .join(',')
+            surefireReportPaths = allSurefireReportDirectories
+                    .getFrom()
+                    .collect { project.relativePath(it) }
+                    .join(',')
         }
 
-        SonarQubeExtension sonarQubeExtension = project.extensions.getByName('sonarqube')
+        SonarQubeExtension sonarQubeExtension = project.extensions.getByName('sonarqube') as SonarQubeExtension
+
         sonarQubeExtension.properties {
             property 'sonar.host.url', 'https://sonarcloud.io'
             property 'sonar.organization', 'black-duck-software'
+
             if (surefireReportPaths) {
                 property 'sonar.junit.reportPaths', surefireReportPaths
+            }
+        }
+
+        if (sonarExcludes.size() > 0) {
+            println "Adding the following exclusions to your sonarqube task:"
+            println "\t" + sonarExcludes
+
+            sonarQubeExtension.properties {
+                property 'sonar.exclusions', sonarExcludes
             }
         }
     }

--- a/src/main/groovy/com/synopsys/integration/Common.groovy
+++ b/src/main/groovy/com/synopsys/integration/Common.groovy
@@ -285,7 +285,7 @@ public abstract class Common implements Plugin<Project> {
     }
 
     public void configureForSonarQube(Project project) {
-        def sonarExcludes = project.ext[PROPERTY_EXCLUDES_FROM_TEST_COVERAGE].toString().replace(".class", ".java").split(", |,| ") as ArrayList
+        def sonarExcludes = project.ext[PROPERTY_EXCLUDES_FROM_TEST_COVERAGE]
 
         def surefireReportPaths = ''
 


### PR DESCRIPTION
Add new property `project.ext.excludesFromTestCoverage` to allow users to exclude individual files or package from Sonar coverage.

Note:
- The property requires an ArrayList as input
- If a user wants to use full path excludes, vs `**/`, it must be the full path to the `.java` file, such as `src/main/java/com/synopsys/integration/jenkins/wrapper/JenkinsVersionHelper.java`

In local tests, the following exclusions were used:
`project.ext.excludesFromTestCoverage = ['**/JenkinsVersionHelper.java', '**/JenkinsWrapper.java', '**/SynopsysCredentialsHelper.*', '**/JenkinsProxyHelper*', '**/jenkins/extensions/*']`

gradle stdout had the following message:
`Applying the following exclusions to your sonarqube task:
        [**/JenkinsVersionHelper.java, **/JenkinsWrapper.java, **/SynopsysCredentialsHelper.*, **/JenkinsProxyHelper*, **/jenkins/extensions/*]`

gradlew debug will show the following:
`10:50:46.725 [INFO] [org.sonarqube.gradle.SonarQubeTask] 7 files ignored because of inclusion/exclusion patterns
10:50:46.725 [INFO] [org.sonarqube.gradle.SonarQubeTask] 0 files ignored because of scm ignore settings`
** 7 files = 4 individual excludes and 3 from excluding package jenkins/extensions