### PR TITLE
New Gradle Task for creating the QA version of Detect Project

### DIFF
--- a/src/main/groovy/com/synopsys/integration/utility/VersionUtility.groovy
+++ b/src/main/groovy/com/synopsys/integration/utility/VersionUtility.groovy
@@ -110,10 +110,13 @@ class VersionUtility {
     String removeBranchNameFromVersion(String currentVersion) {
         if (currentVersion.endsWith(SUFFIX_SNAPSHOT) || currentVersion =~ (SUFFIX_SIGQA + /\d+$/))
             return currentVersion
-        if (currentVersion.contains(SUFFIX_SNAPSHOT))                                           // if -SNAPSHOT isn't in the end, that means the rest is the branch name
+        // if -SNAPSHOT isn't in the end, that means the rest is the branch name
+        if (currentVersion.contains(SUFFIX_SNAPSHOT))
             return currentVersion.replaceAll(/($SUFFIX_SNAPSHOT).*/, '$1')
-        if (currentVersion =~ (SUFFIX_SIGQA + /\d+/))                                           // if -SIGQA[digit] isn't in the end, that means the rest is the branch name
+        // if -SIGQA[digit] isn't in the end, that means the rest is the branch name
+        if (currentVersion =~ (SUFFIX_SIGQA + /\d+/))
             return currentVersion.replaceAll(/($SUFFIX_SIGQA\d+).*/, '$1')
-        return currentVersion.replaceAll(/($VERSION_PATTERN).*/, '$1')         // if none of the above exists, fetch substring upto the version
+        // if none of the above exists, fetch substring upto the version
+        return currentVersion.replaceAll(/($VERSION_PATTERN).*/, '$1')
     }
 }

--- a/src/main/groovy/com/synopsys/integration/utility/VersionUtility.groovy
+++ b/src/main/groovy/com/synopsys/integration/utility/VersionUtility.groovy
@@ -7,6 +7,8 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 class VersionUtility {
+    public static final String PR_PATTERN = '-PR[0-9]+'
+    public static final String IDETECT_PATTERN = '-IDETECT-[0-9]+'
     public static final String SUFFIX_SNAPSHOT = '-SNAPSHOT'
     public static final String SUFFIX_SIGQA = '-SIGQA'
     public static final String VERSION_PATTERN = '(\\d+\\.)(\\d+\\.)(\\d+)((\\.\\d+)*)'
@@ -42,6 +44,17 @@ class VersionUtility {
             } else {
                 version += SUFFIX_SIGQA + '1'
             }
+        }
+        return version
+    }
+
+    String calculateNextQAVersionDetect(String currentVersion) {
+        String version = StringUtils.trimToEmpty(currentVersion)
+        if (StringUtils.isNotBlank(version)) {
+            version = RegExUtils.removePattern(version, PR_PATTERN)
+            version = RegExUtils.removePattern(version, IDETECT_PATTERN)
+            version = removeBranchNameFromVersion(version)
+            version = calculateNextQAVersion(version)
         }
         return version
     }
@@ -82,6 +95,15 @@ class VersionUtility {
             }
         }
         return version
+    }
+
+    static String removeBranchNameFromVersion(String currentVersion) {
+        // considers that PR_PATTERN and IDETECT_PATTERN are already removed.
+        if (currentVersion.contains(SUFFIX_SNAPSHOT) && !(currentVersion.endsWith(SUFFIX_SNAPSHOT)))            // if -SNAPSHOT isn't in the end, that means the rest is the branch name
+            currentVersion = currentVersion.replaceAll(/($SUFFIX_SNAPSHOT).*/, '$1')
+        else if (currentVersion =~ (SUFFIX_SIGQA + /\d+/) && !(currentVersion =~ (SUFFIX_SIGQA + /\d+$/)))      // if -SIGQA isn't in the end, that means the rest is the branch name
+            currentVersion = currentVersion.replaceAll(/($SUFFIX_SIGQA\d+).*/, '$1')
+        return currentVersion
     }
 
 }

--- a/src/test/groovy/com/synopsys/integration/utility/VersionUtilityTest.groovy
+++ b/src/test/groovy/com/synopsys/integration/utility/VersionUtilityTest.groovy
@@ -140,4 +140,58 @@ class VersionUtilityTest {
         assertEquals('4.7.4-SNAPSHOT', version)
     }
 
+    @Test
+    void testVersionSuffixForBranch() {
+        VersionUtility versionUtility = new VersionUtility()
+        assertEquals('dev_name.branch-name-IDETECT-4081', versionUtility.findVersionSuffixForBranch('origin/feature/dev_name/branch-name-IDETECT-4081'))
+        assertEquals('dev_name.branch-name', versionUtility.findVersionSuffixForBranch('origin/dev_name/branch-name'))
+        assertEquals('branch-name', versionUtility.findVersionSuffixForBranch('origin/dev/branch-name'))
+
+        // for RELEASE and MASTER branch, suffix should be empty.
+        assertEquals('', versionUtility.findVersionSuffixForBranch('9.1.z'))
+        assertEquals('', versionUtility.findVersionSuffixForBranch('8.10.0'))
+        assertEquals('', versionUtility.findVersionSuffixForBranch('8.10.32.0'))
+        assertEquals('', versionUtility.findVersionSuffixForBranch('origin/8.10.0'))
+        assertEquals('', versionUtility.findVersionSuffixForBranch('origin/8.10.012.951.z'))
+        assertEquals('', versionUtility.findVersionSuffixForBranch('origin/8.10.0.12.0'))
+        assertEquals('', versionUtility.findVersionSuffixForBranch('origin/master'))
+
+        // the below tests are for WRONG Patterns of RELEASE branch and MASTER branch. So, suffix will not be empty.
+        assertEquals('master-of-puppets', versionUtility.findVersionSuffixForBranch('origin/master-of-puppets'))
+        assertEquals('8.10.12.951..z', versionUtility.findVersionSuffixForBranch('origin/8.10.12.951..z'))
+        assertEquals('8.10.012.951..z', versionUtility.findVersionSuffixForBranch('origin/8.10.012.951..z'))
+        assertEquals('8.10.0.12.1', versionUtility.findVersionSuffixForBranch('origin/8.10.0.12.1'))
+    }
+
+    @Test
+    void testVersionBranchSuffixRemoval() {
+        VersionUtility versionUtility = new VersionUtility()
+        String currentVersion = 'project-name-9.10.1-SIGQA1-dev_name.branch-name'
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+
+        currentVersion = 'project-name-9.10.1-SIGQA1'
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+
+        currentVersion = 'project-name-9.10.1-SNAPSHOT'
+        assertEquals('project-name-9.10.1-SNAPSHOT', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+
+        // the below currentVersion(s) are unexpected to occur. but still handled just in case.
+        currentVersion = 'project-name-9.10.1-SNAPSHOT-dev_name.branch-name'
+        assertEquals('project-name-9.10.1-SNAPSHOT', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA1-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+
+        currentVersion = 'project-name-9.10.1-dev_name.branch-name'
+        assertEquals('project-name-9.10.1', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA1-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+
+        currentVersion = 'project-name-9.10.45.012-dev_name.branch-name'
+        assertEquals('project-name-9.10.45.012', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.45.012-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.45.012-SIGQA1-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+    }
 }


### PR DESCRIPTION
The synopsys-detect project require a new versioning mechanism for its QA builds. Previously, the task responsible for the QA version was qaJaloja. Now, 
- a new Gradle task named qaJalojaDetect is created. The previous qaJaloja task is kept as is, so that not to affect other projects using that.
- Few other methods are also added to help the qaJalojaDetect task. But no existing code was modified.