### PR TITLE
Fix appending multiple branch name to version in Detect release-qa

### DIFF
--- a/src/main/groovy/com/synopsys/integration/utility/VersionUtility.groovy
+++ b/src/main/groovy/com/synopsys/integration/utility/VersionUtility.groovy
@@ -108,12 +108,15 @@ class VersionUtility {
     }
 
     String removeBranchNameFromVersion(String currentVersion) {
-        if (currentVersion.endsWith(SUFFIX_SNAPSHOT) || currentVersion =~ (SUFFIX_SIGQA + /\d+$/))
-            return currentVersion
-        // if -SNAPSHOT isn't in the end, that means the rest is the branch name
+        if (currentVersion.endsWith(SUFFIX_SNAPSHOT)) {
+            if (currentVersion =~ (SUFFIX_SIGQA + /\d+/))
+                return currentVersion.replaceAll(/($SUFFIX_SIGQA\d+).*/, '$1') + SUFFIX_SNAPSHOT
+            return currentVersion.replaceAll(/($VERSION_PATTERN).*/, '$1') + SUFFIX_SNAPSHOT
+        }
+        // if -SNAPSHOT isn't in the end, that means the rest is the branch name. Although -SNAPSHOT should always be at the end.
         if (currentVersion.contains(SUFFIX_SNAPSHOT))
             return currentVersion.replaceAll(/($SUFFIX_SNAPSHOT).*/, '$1')
-        // if -SIGQA[digit] isn't in the end, that means the rest is the branch name
+        // -SNAPSHOT is not present. if -SIGQA[digit] isn't in the end, that means the rest is the branch name
         if (currentVersion =~ (SUFFIX_SIGQA + /\d+/))
             return currentVersion.replaceAll(/($SUFFIX_SIGQA\d+).*/, '$1')
         // if none of the above exists, fetch substring upto the version

--- a/src/main/groovy/com/synopsys/integration/utility/VersionUtility.groovy
+++ b/src/main/groovy/com/synopsys/integration/utility/VersionUtility.groovy
@@ -10,7 +10,7 @@ class VersionUtility {
     public static final String SUFFIX_SNAPSHOT = '-SNAPSHOT'
     public static final String SUFFIX_SIGQA = '-SIGQA'
     public static final String VERSION_PATTERN = '(\\d+\\.)(\\d+\\.)(\\d+)((\\.\\d+)*)'
-    public static final String RELEASE_BRANCH_PATTERN = '(\\d+\\.)(\\d+\\.)((\\d+\\.)*)([0z])'
+    public static final String RELEASE_BRANCH_PATTERN = '(\\d+\\.)(\\d+\\.)((\\d+\\.)*)(\\d+|z)'
 
     String calculateReleaseVersion(String currentVersion) {
         String version = StringUtils.trimToEmpty(currentVersion)

--- a/src/test/groovy/com/synopsys/integration/utility/VersionUtilityTest.groovy
+++ b/src/test/groovy/com/synopsys/integration/utility/VersionUtilityTest.groovy
@@ -170,6 +170,11 @@ class VersionUtilityTest {
         assertEquals('project-name-9.10.1-SIGQA1', versionUtility.removeBranchNameFromVersion(currentVersion))
         assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
 
+        currentVersion = 'project-name-9.10.1-SIGQA1-dev_name.branch-name-SNAPSHOT'
+        assertEquals('project-name-9.10.1-SIGQA1-SNAPSHOT', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA2-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA1'))
+
         currentVersion = 'project-name-9.10.1-SIGQA1'
         assertEquals('project-name-9.10.1-SIGQA1', versionUtility.removeBranchNameFromVersion(currentVersion))
         assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
@@ -193,5 +198,45 @@ class VersionUtilityTest {
         assertEquals('project-name-9.10.45.012', versionUtility.removeBranchNameFromVersion(currentVersion))
         assertEquals('project-name-9.10.45.012-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
         assertEquals('project-name-9.10.45.012-SIGQA1-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+    }
+
+    @Test
+    void allPossibleCurrentVersionsTest() {
+        VersionUtility versionUtility = new VersionUtility()
+        String currentVersion = 'project-name-9.10.1'
+        assertEquals('project-name-9.10.1', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA1-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA1-dev_name.branch-name'))
+
+        currentVersion = 'project-name-9.10.1-SNAPSHOT'
+        assertEquals('project-name-9.10.1-SNAPSHOT', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA1-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion,'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA1-dev_name.branch-name'))
+
+        currentVersion = 'project-name-9.10.1-SIGQA2'
+        assertEquals('project-name-9.10.1-SIGQA2', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA3', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA3-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA4-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA3-dev_name.branch-name'))
+
+        currentVersion = 'project-name-9.10.1-SIGQA2-SNAPSHOT'
+        assertEquals('project-name-9.10.1-SIGQA2-SNAPSHOT', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA3-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA2-dev_name.branch-name'))
+
+        currentVersion = 'project-name-9.10.1-SIGQA2-dev_name.branch-name'
+        assertEquals('project-name-9.10.1-SIGQA2', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA3', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA3-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA4-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA3-dev_name.branch-name'))
+
+        currentVersion = 'project-name-9.10.1-SIGQA2-dev_name.branch-name-SNAPSHOT'
+        assertEquals('project-name-9.10.1-SIGQA2-SNAPSHOT', versionUtility.removeBranchNameFromVersion(currentVersion))
+        assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA3-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA2-dev_name.branch-name'))
     }
 }

--- a/src/test/groovy/com/synopsys/integration/utility/VersionUtilityTest.groovy
+++ b/src/test/groovy/com/synopsys/integration/utility/VersionUtilityTest.groovy
@@ -150,17 +150,19 @@ class VersionUtilityTest {
         // for RELEASE and MASTER branch, suffix should be empty.
         assertEquals('', versionUtility.findVersionSuffixForBranch('9.1.z'))
         assertEquals('', versionUtility.findVersionSuffixForBranch('8.10.0'))
+        assertEquals('', versionUtility.findVersionSuffixForBranch('8.10.11'))
         assertEquals('', versionUtility.findVersionSuffixForBranch('8.10.32.0'))
         assertEquals('', versionUtility.findVersionSuffixForBranch('origin/8.10.0'))
         assertEquals('', versionUtility.findVersionSuffixForBranch('origin/8.10.012.951.z'))
         assertEquals('', versionUtility.findVersionSuffixForBranch('origin/8.10.0.12.0'))
+        assertEquals('', versionUtility.findVersionSuffixForBranch('origin/8.10.0.12.1'))
         assertEquals('', versionUtility.findVersionSuffixForBranch('origin/master'))
 
         // the below tests are for WRONG Patterns of RELEASE branch and MASTER branch. So, suffix will not be empty.
         assertEquals('master-of-puppets', versionUtility.findVersionSuffixForBranch('origin/master-of-puppets'))
         assertEquals('8.10.12.951..z', versionUtility.findVersionSuffixForBranch('origin/8.10.12.951..z'))
         assertEquals('8.10.012.951..z', versionUtility.findVersionSuffixForBranch('origin/8.10.012.951..z'))
-        assertEquals('8.10.0.12.1', versionUtility.findVersionSuffixForBranch('origin/8.10.0.12.1'))
+        assertEquals('8.10.za', versionUtility.findVersionSuffixForBranch('origin/8.10.za'))
     }
 
     @Test
@@ -206,37 +208,55 @@ class VersionUtilityTest {
         String currentVersion = 'project-name-9.10.1'
         assertEquals('project-name-9.10.1', versionUtility.removeBranchNameFromVersion(currentVersion))
         assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.z'))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.0'))
         assertEquals('project-name-9.10.1-SIGQA1-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA2-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA1'))
         assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA1-dev_name.branch-name'))
 
         currentVersion = 'project-name-9.10.1-SNAPSHOT'
         assertEquals('project-name-9.10.1-SNAPSHOT', versionUtility.removeBranchNameFromVersion(currentVersion))
         assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.z'))
+        assertEquals('project-name-9.10.1-SIGQA1', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.0'))
         assertEquals('project-name-9.10.1-SIGQA1-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion,'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA2-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA1'))
         assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA1-dev_name.branch-name'))
 
         currentVersion = 'project-name-9.10.1-SIGQA2'
         assertEquals('project-name-9.10.1-SIGQA2', versionUtility.removeBranchNameFromVersion(currentVersion))
         assertEquals('project-name-9.10.1-SIGQA3', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA3', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.z'))
+        assertEquals('project-name-9.10.1-SIGQA3', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.1'))
         assertEquals('project-name-9.10.1-SIGQA3-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA4-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA3'))
         assertEquals('project-name-9.10.1-SIGQA4-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA3-dev_name.branch-name'))
 
         currentVersion = 'project-name-9.10.1-SIGQA2-SNAPSHOT'
         assertEquals('project-name-9.10.1-SIGQA2-SNAPSHOT', versionUtility.removeBranchNameFromVersion(currentVersion))
         assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.z'))
+        assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.1'))
         assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA3-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA2'))
         assertEquals('project-name-9.10.1-SIGQA3-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA2-dev_name.branch-name'))
 
         currentVersion = 'project-name-9.10.1-SIGQA2-dev_name.branch-name'
         assertEquals('project-name-9.10.1-SIGQA2', versionUtility.removeBranchNameFromVersion(currentVersion))
         assertEquals('project-name-9.10.1-SIGQA3', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA3', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.z'))
+        assertEquals('project-name-9.10.1-SIGQA3', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.1'))
         assertEquals('project-name-9.10.1-SIGQA3-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA4-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA3'))
         assertEquals('project-name-9.10.1-SIGQA4-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA3-dev_name.branch-name'))
 
         currentVersion = 'project-name-9.10.1-SIGQA2-dev_name.branch-name-SNAPSHOT'
         assertEquals('project-name-9.10.1-SIGQA2-SNAPSHOT', versionUtility.removeBranchNameFromVersion(currentVersion))
         assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/master'))
+        assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.z'))
+        assertEquals('project-name-9.10.1-SIGQA2', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/9.10.1'))
         assertEquals('project-name-9.10.1-SIGQA2-dev_name.branch-name', versionUtility.calculateNextQAVersionDetect(currentVersion, 'origin/dev_name/branch-name'))
+        assertEquals('project-name-9.10.1-SIGQA3-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA2'))
         assertEquals('project-name-9.10.1-SIGQA3-dev_name.branch-name-SNAPSHOT', versionUtility.calculateNextSnapshot('project-name-9.10.1-SIGQA2-dev_name.branch-name'))
     }
 }


### PR DESCRIPTION
Details of the bug is described in [IDETECT-4220](https://synopsyssig.atlassian.net/browse/IDETECT-4220).

Solve:
Removed whatever is in between `-SIGQA[digit]` and `-SNAPSHOT`.
Removed whatever is in between version pattern (i.e., `9.4.0`) and `-SNAPSHOT` if no `-SIGQA[digit]` exists.
Removed whatever is after `-SIGQA[digit]`  if no `-SNAPSHOT` exists.
Removed whatever is after version pattern (i.e., `9.4.0`) if neither `-SNAPSHOT` nor `-SIGQA[digit]` exists.

This [test method](https://github.com/blackducksoftware/common-gradle-plugin/blob/8c5f8f53e41ef3d18571e913994536000f659108/src/test/groovy/com/synopsys/integration/utility/VersionUtilityTest.groovy#L204) tests all possible use cases. Kindly check this out to see if any use case is missed out.